### PR TITLE
Update yum prod LFS repo name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,11 @@ jobs:
 
       - run:
           name: Clone the repository with LFS
-          command: git clone --depth=1 -b ${CIRCLE_BRANCH} https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs
+          command: git clone --depth=1 -b ${CIRCLE_BRANCH} https://github.com/freedomofpress/securedrop-yum-prod
       - run:
           name: Verify the signatures of all rpm artifacts
           command: |
-            cd securedrop-workstation-prod-rpm-packages-lfs
+            cd securedrop-yum-prod
             git-lfs install
             ./scripts/check.py --verify --all
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > By contributing to this project, you agree to abide by our [Code of Conduct](https://github.com/freedomofpress/.github/blob/main/CODE_OF_CONDUCT.md).
 
-# securedrop-workstation-prod-rpm-packages-lfs
+# securedrop-yum-prod
 
 Repository for storing stable builds of [SecureDrop Workstation](https://github.com/freedomofpress/securedrop-workstation)
 packages for distribution to production Workstation installs. The packages here are RPMs, intended for installation


### PR DESCRIPTION
Not a package PR, so removing the usual checklist for that -- rather, this updates references to the name of this repo itself per our rename plan in https://github.com/freedomofpress/securedrop-builder/issues/304. There's a README change and a CircleCI change, and the latter will fail at the moment because the rename has not happened yet, but should work later today after that is done.
