### PR TITLE
Add securedrop-workstation-dom0-config 0.8.0

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.8.0-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.8.0-1.fc32.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb74d320a5c771d6d630a406794cc01bc0bbd9d31be06e0108f6a4dc9f96413c
+oid sha256:1a98dabb5e0df0ab8b1c5c22fae90792d6347e3dc9d5eec0fd640e074c52c31f
 size 117039

--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.8.0-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.8.0-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb74d320a5c771d6d630a406794cc01bc0bbd9d31be06e0108f6a4dc9f96413c
+size 117039


### PR DESCRIPTION
Refs <https://github.com/freedomofpress/securedrop-workstation/issues/866>.

###
Name of package: securedrop-workstation-dom0-config


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.8.0
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/e9cc1435adff95fe8bd316672d61972f1275aab6
- [x] CI is passing, the rpm is properly signed with the prod key
- [x] Unsigned RPM after running `rpm --delsign` (using Debian buster) on the signed RPM results in the checksum found in the build logs
