### PR TITLE
Deploy updated qubes template to yum-qa

### DIFF
--- a/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.1-202306151618.noarch.rpm
+++ b/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.1-202306151618.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea46f6fd9eab32df46b52798d47b46965c0950e568349b36ce9b430f56b38981
+size 1039498318

--- a/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.1-202306151618.noarch.rpm
+++ b/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.1-202306151618.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ea46f6fd9eab32df46b52798d47b46965c0950e568349b36ce9b430f56b38981
+oid sha256:0ba66f32970be47fd52465a69abdfbde86cc0913d2b9b37b30a7e01e49d359a7
 size 1039498318


### PR DESCRIPTION
###
Towards https://github.com/freedomofpress/securedrop-workstation/issues/888 
Closes https://github.com/freedomofpress/securedrop-workstation/issues/887

Name of package: qubes-template-securedrop-workstation-bullseye-4.1-202306151618

### Test plan

- [x] Base branch is `release`, so we deploy to yum-qa
- [x] ~Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/x.y.z~ No tag, per  https://github.com/freedomofpress/securedrop-workstation/issues/887#issuecomment-1594979505
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/a3539dcfbfe05fe98f2f21657c38a1519f5a508c
- [x] CI is passing, the rpm is properly signed with the prod key
- [x] Unsigned RPM after running `rpm --delsign` ~(in Debian Stable)~ **in a consistent OS with rpm version >= 4.18.1** on the signed RPM results in the checksum found in the build logs
