### PR TITLE
Release qubes-template-securedrop-workstation-bullseye-4.1-202306151618

### DIFF
--- a/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.1-202306151618.noarch.rpm
+++ b/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.1-202306151618.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ba66f32970be47fd52465a69abdfbde86cc0913d2b9b37b30a7e01e49d359a7
+size 1039498318


### PR DESCRIPTION
Fixes https://github.com/freedomofpress/securedrop-workstation/issues/888

Name of package: qubes-template-securedrop-workstation-bullseye-4.1-202306151618

As this merges `release` into `main`, this is essentially a package promotion PR, please see https://github.com/freedomofpress/securedrop-yum-prod/pull/43 for build log and other information about the actual package.

### Test plan

- [x] Source branch is `release`, target branch is `main`
- [x] https://github.com/freedomofpress/securedrop-workstation/issues/888 concluded the template can be installed successfully
- [x] All changes in this PR pertain to qubes-template-securedrop-workstation-bullseye-4.1-202306151618
- [x] CI is happy