### PR TITLE
Add securedrop-workstation-dom0-config-0.8.1-1.fc32.noarch.rpm

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.8.1-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.8.1-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:931b47a2c2a47b32f3338185bd6552ed476badd798692680c0a8ad454d00849e
+size 117136


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-workstation/issues/903

###
Name of package: securedrop-workstation-dom0-config


### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.8.1
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/74f0ee82c4d18cfe704c5883e0dc581b63dcd1e0
- [ ] CI is passing, the rpm is properly signed with the prod key
- [ ] Unsigned RPM after running `rpm --delsign` (**using rpm version >= 4.18.1**) on the signed RPM results in the checksum found in the build logs

