### PR TITLE
Generate and maintain repository metadata in tree

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 *.deb filter=lfs diff=lfs merge=lfs -text
 *.rpm filter=lfs diff=lfs merge=lfs -text
+*.gz filter=lfs diff=lfs merge=lfs -text
+*.bz2 filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 
 on: [push, pull_request]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -33,3 +37,22 @@ jobs:
       - name: Output the hashes of all rpm artifacts without their signatures
         run: |
           ./scripts/check.py --check-unsigned --all
+
+  metadata:
+    runs-on: ubuntu-latest
+    container: debian:bookworm
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update && apt-get install --yes python3 git git-lfs createrepo-c
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+          fetch-depth: 0
+      - name: Check repository metadata is up-to-date
+        run: |
+          git config --global --add safe.directory '*'
+          ./tools/publish-real --reproduce
+          git status
+          git diff --exit-code

--- a/public/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135.noarch.rpm
+++ b/public/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1eb8b2447baaa495b961ad9a189e30c9bc267e1e0d00b299958702950ebdd645
+size 894939705

--- a/public/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.1-202306151618.noarch.rpm
+++ b/public/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.1-202306151618.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ba66f32970be47fd52465a69abdfbde86cc0913d2b9b37b30a7e01e49d359a7
+size 1039498318

--- a/public/workstation/dom0/f32/repodata/201484ffa7e3ca3bc3e55f649b0a561826f7bf0caca417bf739865379d0039ba-other.sqlite.bz2
+++ b/public/workstation/dom0/f32/repodata/201484ffa7e3ca3bc3e55f649b0a561826f7bf0caca417bf739865379d0039ba-other.sqlite.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:201484ffa7e3ca3bc3e55f649b0a561826f7bf0caca417bf739865379d0039ba
+size 3360

--- a/public/workstation/dom0/f32/repodata/459b1903f2ab64d76e3ecbf085eb87c58a9492912a3dfc2ce2947591ad449921-filelists.xml.gz
+++ b/public/workstation/dom0/f32/repodata/459b1903f2ab64d76e3ecbf085eb87c58a9492912a3dfc2ce2947591ad449921-filelists.xml.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:459b1903f2ab64d76e3ecbf085eb87c58a9492912a3dfc2ce2947591ad449921
+size 2316

--- a/public/workstation/dom0/f32/repodata/9df6ebad27017462079510ee060951acd03b166e639e64026412c3c501fac89a-other.xml.gz
+++ b/public/workstation/dom0/f32/repodata/9df6ebad27017462079510ee060951acd03b166e639e64026412c3c501fac89a-other.xml.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9df6ebad27017462079510ee060951acd03b166e639e64026412c3c501fac89a
+size 1647

--- a/public/workstation/dom0/f32/repodata/a5e36397022236443aa92497a7bb622a3eeb90068280121d9e84a8bc5b9ed517-filelists.sqlite.bz2
+++ b/public/workstation/dom0/f32/repodata/a5e36397022236443aa92497a7bb622a3eeb90068280121d9e84a8bc5b9ed517-filelists.sqlite.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5e36397022236443aa92497a7bb622a3eeb90068280121d9e84a8bc5b9ed517
+size 6225

--- a/public/workstation/dom0/f32/repodata/ccbfb660d99a2833c1e5c194b76440784266c8fad00b57f46595dc3334c06f73-primary.xml.gz
+++ b/public/workstation/dom0/f32/repodata/ccbfb660d99a2833c1e5c194b76440784266c8fad00b57f46595dc3334c06f73-primary.xml.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccbfb660d99a2833c1e5c194b76440784266c8fad00b57f46595dc3334c06f73
+size 1845

--- a/public/workstation/dom0/f32/repodata/f32c1c04cd246fd090eaf91db84d81936681df0ff2265601839a89d966c353de-primary.sqlite.bz2
+++ b/public/workstation/dom0/f32/repodata/f32c1c04cd246fd090eaf91db84d81936681df0ff2265601839a89d966c353de-primary.sqlite.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f32c1c04cd246fd090eaf91db84d81936681df0ff2265601839a89d966c353de
+size 4559

--- a/public/workstation/dom0/f32/repodata/repomd.xml
+++ b/public/workstation/dom0/f32/repodata/repomd.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+  <revision>1741376829</revision>
+  <data type="primary">
+    <checksum type="sha256">ccbfb660d99a2833c1e5c194b76440784266c8fad00b57f46595dc3334c06f73</checksum>
+    <open-checksum type="sha256">e5719429506d2ecbb8daa112d0d8644df5eb3cf3d4c8f355ec8fdc2a13a37ad3</open-checksum>
+    <location href="repodata/ccbfb660d99a2833c1e5c194b76440784266c8fad00b57f46595dc3334c06f73-primary.xml.gz"/>
+    <timestamp>1741376829</timestamp>
+    <size>1845</size>
+    <open-size>14658</open-size>
+  </data>
+  <data type="filelists">
+    <checksum type="sha256">459b1903f2ab64d76e3ecbf085eb87c58a9492912a3dfc2ce2947591ad449921</checksum>
+    <open-checksum type="sha256">f0b7a1c551f36129a18fcca753ea64a6e880a843e5236b0921c8227b2aeab497</open-checksum>
+    <location href="repodata/459b1903f2ab64d76e3ecbf085eb87c58a9492912a3dfc2ce2947591ad449921-filelists.xml.gz"/>
+    <timestamp>1741376829</timestamp>
+    <size>2316</size>
+    <open-size>42115</open-size>
+  </data>
+  <data type="other">
+    <checksum type="sha256">9df6ebad27017462079510ee060951acd03b166e639e64026412c3c501fac89a</checksum>
+    <open-checksum type="sha256">2cfde3d045513efda282c246168dcfd0650d4e7bf9ae68f3d09d2f72da35e501</open-checksum>
+    <location href="repodata/9df6ebad27017462079510ee060951acd03b166e639e64026412c3c501fac89a-other.xml.gz"/>
+    <timestamp>1741376829</timestamp>
+    <size>1647</size>
+    <open-size>13444</open-size>
+  </data>
+  <data type="primary_db">
+    <checksum type="sha256">f32c1c04cd246fd090eaf91db84d81936681df0ff2265601839a89d966c353de</checksum>
+    <open-checksum type="sha256">0e076394d65757619be78d07296195bc404713fb1368a103d5bf180f20cb3b76</open-checksum>
+    <location href="repodata/f32c1c04cd246fd090eaf91db84d81936681df0ff2265601839a89d966c353de-primary.sqlite.bz2"/>
+    <timestamp>1741376829</timestamp>
+    <size>4559</size>
+    <open-size>114688</open-size>
+    <database_version>10</database_version>
+  </data>
+  <data type="filelists_db">
+    <checksum type="sha256">a5e36397022236443aa92497a7bb622a3eeb90068280121d9e84a8bc5b9ed517</checksum>
+    <open-checksum type="sha256">b2001b79a2c36488da07238b6c37bc7d354b07358c73d93475e68da1d2aefb24</open-checksum>
+    <location href="repodata/a5e36397022236443aa92497a7bb622a3eeb90068280121d9e84a8bc5b9ed517-filelists.sqlite.bz2"/>
+    <timestamp>1741376829</timestamp>
+    <size>6225</size>
+    <open-size>57344</open-size>
+    <database_version>10</database_version>
+  </data>
+  <data type="other_db">
+    <checksum type="sha256">201484ffa7e3ca3bc3e55f649b0a561826f7bf0caca417bf739865379d0039ba</checksum>
+    <open-checksum type="sha256">f85208b7130bff6da33a11322668316f313f2d91898f58880f99d1dfe1340f6c</open-checksum>
+    <location href="repodata/201484ffa7e3ca3bc3e55f649b0a561826f7bf0caca417bf739865379d0039ba-other.sqlite.bz2"/>
+    <timestamp>1741376829</timestamp>
+    <size>3360</size>
+    <open-size>36864</open-size>
+    <database_version>10</database_version>
+  </data>
+</repomd>

--- a/public/workstation/dom0/f32/securedrop-workstation-dom0-config-0.10.0-1.fc32.noarch.rpm
+++ b/public/workstation/dom0/f32/securedrop-workstation-dom0-config-0.10.0-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:704444e67ccb18961e491247819639e3bc2bfbbc492afacfba705636d7c689e9
+size 95581

--- a/public/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.0-1.fc32.noarch.rpm
+++ b/public/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.0-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47a87cf95001e365eff54f04fa2dba022933d8603f6512918ae741fe3eb248b3
+size 96999

--- a/public/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.1-1.fc32.noarch.rpm
+++ b/public/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.1-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c2a014db4102aeed6fc7d4ed108035f4dddc53715a5d8ab28629c020c395e6b
+size 102023

--- a/public/workstation/dom0/f32/securedrop-workstation-dom0-config-0.7.0-1.fc32.noarch.rpm
+++ b/public/workstation/dom0/f32/securedrop-workstation-dom0-config-0.7.0-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:274a5540373397a791008d3b1dc02071ea87231c6c0824481597c38c45596ffe
+size 127731

--- a/public/workstation/dom0/f32/securedrop-workstation-dom0-config-0.8.0-1.fc32.noarch.rpm
+++ b/public/workstation/dom0/f32/securedrop-workstation-dom0-config-0.8.0-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a98dabb5e0df0ab8b1c5c22fae90792d6347e3dc9d5eec0fd640e074c52c31f
+size 117039

--- a/public/workstation/dom0/f32/securedrop-workstation-dom0-config-0.8.1-1.fc32.noarch.rpm
+++ b/public/workstation/dom0/f32/securedrop-workstation-dom0-config-0.8.1-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea7b2d15fefd155f2fb85b521b90f58acdc36a079964a5b7ec8e4dcd3f460256
+size 117136

--- a/public/workstation/dom0/f32/securedrop-workstation-dom0-config-0.9.0-1.fc32.noarch.rpm
+++ b/public/workstation/dom0/f32/securedrop-workstation-dom0-config-0.9.0-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ae13cdd4a54e4f7ce3c0e588da75a6e939bb5d47f7f4e0a425535b12540e457
+size 95360

--- a/public/workstation/dom0/f37/repodata/17f2636ea9e44e3f61411e8517274ea09de89c97f33f889fac819f225e43d534-primary.xml.gz
+++ b/public/workstation/dom0/f37/repodata/17f2636ea9e44e3f61411e8517274ea09de89c97f33f889fac819f225e43d534-primary.xml.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17f2636ea9e44e3f61411e8517274ea09de89c97f33f889fac819f225e43d534
+size 1302

--- a/public/workstation/dom0/f37/repodata/2ce73f4380223cd96178ae862820176b693d2c5e3d721b9e54a9192909ee8836-filelists.xml.gz
+++ b/public/workstation/dom0/f37/repodata/2ce73f4380223cd96178ae862820176b693d2c5e3d721b9e54a9192909ee8836-filelists.xml.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ce73f4380223cd96178ae862820176b693d2c5e3d721b9e54a9192909ee8836
+size 1626

--- a/public/workstation/dom0/f37/repodata/95ec41a294ceb22f918ac98cbfef2e530738a87c41e1ef15d7a5b17cc860a55c-filelists.sqlite.bz2
+++ b/public/workstation/dom0/f37/repodata/95ec41a294ceb22f918ac98cbfef2e530738a87c41e1ef15d7a5b17cc860a55c-filelists.sqlite.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95ec41a294ceb22f918ac98cbfef2e530738a87c41e1ef15d7a5b17cc860a55c
+size 4152

--- a/public/workstation/dom0/f37/repodata/99a65c95998af81faa4d367eddc86ba3eefa5d20e0fd372a278985baded3b282-other.sqlite.bz2
+++ b/public/workstation/dom0/f37/repodata/99a65c95998af81faa4d367eddc86ba3eefa5d20e0fd372a278985baded3b282-other.sqlite.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99a65c95998af81faa4d367eddc86ba3eefa5d20e0fd372a278985baded3b282
+size 1945

--- a/public/workstation/dom0/f37/repodata/aba688f5afda7f2862af7efcd41886dc884f57e15fe064a44a7075864711fce1-other.xml.gz
+++ b/public/workstation/dom0/f37/repodata/aba688f5afda7f2862af7efcd41886dc884f57e15fe064a44a7075864711fce1-other.xml.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aba688f5afda7f2862af7efcd41886dc884f57e15fe064a44a7075864711fce1
+size 780

--- a/public/workstation/dom0/f37/repodata/cb480a1a8bed68e5b3fa765164cd3f2648c3ea7e9bce791dcf35b0fc34418b04-primary.sqlite.bz2
+++ b/public/workstation/dom0/f37/repodata/cb480a1a8bed68e5b3fa765164cd3f2648c3ea7e9bce791dcf35b0fc34418b04-primary.sqlite.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb480a1a8bed68e5b3fa765164cd3f2648c3ea7e9bce791dcf35b0fc34418b04
+size 3982

--- a/public/workstation/dom0/f37/repodata/repomd.xml
+++ b/public/workstation/dom0/f37/repodata/repomd.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+  <revision>1741376829</revision>
+  <data type="primary">
+    <checksum type="sha256">17f2636ea9e44e3f61411e8517274ea09de89c97f33f889fac819f225e43d534</checksum>
+    <open-checksum type="sha256">f0bc3b049fa419486d8890c379a51e3ed57cc668fe2320f70a470f3ad4d881e6</open-checksum>
+    <location href="repodata/17f2636ea9e44e3f61411e8517274ea09de89c97f33f889fac819f225e43d534-primary.xml.gz"/>
+    <timestamp>1741376829</timestamp>
+    <size>1302</size>
+    <open-size>9135</open-size>
+  </data>
+  <data type="filelists">
+    <checksum type="sha256">2ce73f4380223cd96178ae862820176b693d2c5e3d721b9e54a9192909ee8836</checksum>
+    <open-checksum type="sha256">ede8301d50716b1c105f34aa23c7e248710c0e226c7384a5eef3317499c65d82</open-checksum>
+    <location href="repodata/2ce73f4380223cd96178ae862820176b693d2c5e3d721b9e54a9192909ee8836-filelists.xml.gz"/>
+    <timestamp>1741376829</timestamp>
+    <size>1626</size>
+    <open-size>24877</open-size>
+  </data>
+  <data type="other">
+    <checksum type="sha256">aba688f5afda7f2862af7efcd41886dc884f57e15fe064a44a7075864711fce1</checksum>
+    <open-checksum type="sha256">1ba90bb9bb86ce8624dabc865735f70c704277a8c238c0dd17de61ae54588de2</open-checksum>
+    <location href="repodata/aba688f5afda7f2862af7efcd41886dc884f57e15fe064a44a7075864711fce1-other.xml.gz"/>
+    <timestamp>1741376829</timestamp>
+    <size>780</size>
+    <open-size>6533</open-size>
+  </data>
+  <data type="primary_db">
+    <checksum type="sha256">cb480a1a8bed68e5b3fa765164cd3f2648c3ea7e9bce791dcf35b0fc34418b04</checksum>
+    <open-checksum type="sha256">5053c43654970ccbda2f6e2f3dd2e7587984a85acfa17a44351bb50e94748d9b</open-checksum>
+    <location href="repodata/cb480a1a8bed68e5b3fa765164cd3f2648c3ea7e9bce791dcf35b0fc34418b04-primary.sqlite.bz2"/>
+    <timestamp>1741376829</timestamp>
+    <size>3982</size>
+    <open-size>106496</open-size>
+    <database_version>10</database_version>
+  </data>
+  <data type="filelists_db">
+    <checksum type="sha256">95ec41a294ceb22f918ac98cbfef2e530738a87c41e1ef15d7a5b17cc860a55c</checksum>
+    <open-checksum type="sha256">697d06908394d05c1a3e3ce0b847fac1d9e910dfe1236f7d5ee76b23e376d6cb</open-checksum>
+    <location href="repodata/95ec41a294ceb22f918ac98cbfef2e530738a87c41e1ef15d7a5b17cc860a55c-filelists.sqlite.bz2"/>
+    <timestamp>1741376829</timestamp>
+    <size>4152</size>
+    <open-size>40960</open-size>
+    <database_version>10</database_version>
+  </data>
+  <data type="other_db">
+    <checksum type="sha256">99a65c95998af81faa4d367eddc86ba3eefa5d20e0fd372a278985baded3b282</checksum>
+    <open-checksum type="sha256">2d07b14f4feca1b9ef27bec655b4a813c57d0aa94135167205afc2ed37983a58</open-checksum>
+    <location href="repodata/99a65c95998af81faa4d367eddc86ba3eefa5d20e0fd372a278985baded3b282-other.sqlite.bz2"/>
+    <timestamp>1741376829</timestamp>
+    <size>1945</size>
+    <open-size>24576</open-size>
+    <database_version>10</database_version>
+  </data>
+</repomd>

--- a/public/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.0-1.fc37.noarch.rpm
+++ b/public/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.0-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2390a426a385c7d8d778fbc92f4dbab805ab75caf83e257b3161cf4d2fb23cec
+size 92512

--- a/public/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.2-1.fc37.noarch.rpm
+++ b/public/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.2-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d38333b3fb8a0225edab7a31acde2cfd9a1dd2a524ff3ae69839374207341d8b
+size 92431

--- a/public/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.0-1.fc37.noarch.rpm
+++ b/public/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.0-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:425be02c75e894b1a6e7f063691ddfe6460a272dd1305bff07626b6a08fe4fd3
+size 93430

--- a/public/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.1-1.fc37.noarch.rpm
+++ b/public/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.1-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:108273fb4d1886a4c387f1b0c46096e92b605127cee40828a89ef43dbef51e2d
+size 93496

--- a/tools/publish
+++ b/tools/publish
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Pull the latest image
+podman pull debian:bookworm
+# Mount the git repo to /srv, install necessary packages and run the publish script
+podman run --rm -it -v $(git rev-parse --show-toplevel):/srv:Z debian:bookworm \
+    bash -c "apt-get update && apt-get install -y python3 createrepo-c && /srv/tools/publish-real $@"

--- a/tools/publish-real
+++ b/tools/publish-real
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+Script for generating yum repository metadata in a reproducible manner.
+
+Files are copied into public/ and metadata is generated there. All RPMs
+have their mtime fixed to a specific timestamp, so the generated XML/SQLite
+files will be reproducible.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+
+def fetch_reproduce_timestamp(public: Path) -> int:
+    repomd = next(public.glob("workstation/dom0/*/repodata/repomd.xml"))
+    tree = ET.parse(repomd)
+    root = tree.getroot()
+    revision = root.find(
+        "repo:revision", {"repo": "http://linux.duke.edu/metadata/repo"}
+    )
+    print(f"Will use a timestamp of {revision.text} (from {repomd})")
+    return int(revision.text)
+
+
+def main():
+    root = Path(__file__).parent.parent
+    public = root / "public"
+    workstation = root / "workstation"
+    if "--reproduce" in sys.argv:
+        try:
+            timestamp = fetch_reproduce_timestamp(public)
+        except Exception as err:
+            raise RuntimeError("Failed to fetch timestamp from repomd.xml") from err
+    else:
+        # Use the current time
+        timestamp = int(time.time())
+    # Reset public, copy the workstation/ tree into it
+    print("Creating public/ (from scratch)")
+    if public.exists():
+        shutil.rmtree(public)
+    public.mkdir()
+    shutil.copytree(workstation, public / "workstation")
+    for rpm in public.glob("**/*.rpm"):
+        os.utime(rpm, (timestamp, timestamp))
+    # Folders are public/workstation/dom0/fXX, run createrepo_c in each one
+    for folder in public.glob("*/*/*/"):
+        if not folder.is_dir():
+            continue
+        print(f"Generating metadata for {folder}")
+        # The <revision> and <timestamp> fields are set to the current UNIX time
+        # unless we explicitly override them. Use our fixed time to ensure it's
+        # consistent regardless of how long this command takes to run.
+        subprocess.check_call(
+            [
+                "createrepo_c",
+                "--revision",
+                str(timestamp),
+                "--set-timestamp-to-revision",
+                str(folder),
+            ]
+        )
+    print("Done!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Let's match the securedrop-apt-prod process by generating metadata at
commit-time instead of doing it on the server.

The publish script takes care to generate reproducible output by
fixing the mtime of all the RPMs and telling `createrepo_c` what the
time should be.

CI verifies the generated metadata is up to date and fully reproducible
using the `--reproduce` flag.

Refs <https://github.com/freedomofpress/infrastructure/issues/4241>.

## Test plan
* [ ] Visual review
* [ ] CI passes
* [ ] Add any RPM to the f37 folder, run `./tools/publish` locally, see metadata files change. Stage these changes
* [ ] Run `./tools/publish --reproduce`, you should see no changes to the files compared to the previous step