### PR TITLE
Release SecureDrop Workstation 0.9.0

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.9.0-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.9.0-1.fc32.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:071f1dd6a43f54dcfbdc6109d96d16bbc32a9ed5ab862e804f055dc9a2d0f953
+oid sha256:7ae13cdd4a54e4f7ce3c0e588da75a6e939bb5d47f7f4e0a425535b12540e457
 size 95360

--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.9.0-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.9.0-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:071f1dd6a43f54dcfbdc6109d96d16bbc32a9ed5ab862e804f055dc9a2d0f953
+size 95360


### PR DESCRIPTION
###
Name of package:
securedrop-workstation-dom0-config-0.9.0-1.fc32.noarch.rpm

### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.9.0
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/1db415abd540aaec38bd85813debd931b14dc401
- [x] CI is passing, the rpm is properly signed with the prod key
- [x] Unsigned RPM after running `rpm --delsign` (in Debian Stable) on the signed RPM results in the checksum found in the build logs
