### PR TITLE
SecureDrop Workstation 0.10.0

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.10.0-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.10.0-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:704444e67ccb18961e491247819639e3bc2bfbbc492afacfba705636d7c689e9
+size 95581


### PR DESCRIPTION
###
Name of package:
securedrop-workstation-dom0-config-0.10.0-1.fc32.noarch.rpm

### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.10.0
- [ ] Build logs are included:https://github.com/freedomofpress/build-logs/commit/fa1b3768c209d2e6c5b60e925c713916d0d52341
- [ ] CI is passing, the rpm is properly signed with the prod key
- [ ] Unsigned RPM after running `rpm --delsign` (in Debian Stable) on the signed RPM results in the checksum found in the build logs
