### PR TITLE
Release securedrop-workstation-dom0-config 0.11.0

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.0-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.0-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2f885be683c06fc420c69a0be9ba105e1a97b8296468f6a24f82c726fd94d5a
+size 96999

--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.0-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.0-1.fc32.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2f885be683c06fc420c69a0be9ba105e1a97b8296468f6a24f82c726fd94d5a
+oid sha256:47a87cf95001e365eff54f04fa2dba022933d8603f6512918ae741fe3eb248b3
 size 96999


### PR DESCRIPTION
###
securedrop-workstation-dom0-config

### Packaging test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/x.y.z
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/b7e4786ba6cb2630559457e88fddd439af20740b
- [ ] CI is passing, the rpm is properly signed with the prod key
- [ ] Unsigned RPM after running `rpm --delsign` (in Debian Stable) on the signed RPM results in the checksum found in the build logs

Package is  available on yum-qa.securedrop.org.

Before approval and merge, preflight tests are required for the following:
- [x] upgrade from 0.10.0 on Qubes 4.1 with fedora-39 templates preinstalled
- [ ] upgrade from 0.10.0 on Qubes 4.1 with fedora-39 templates not installed
- [x] fresh install on Qubes 4.1.2

See https://github.com/freedomofpress/securedrop-workstation/issues/999 for more information and a test plan.
