### PR TITLE
Add securedrop-workstation-dom0-config-0.11.1

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.1-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.1-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8e172dfac20d0631d39c5fd3cb3ff5c3ea0cef4bccc666451557336531e041b
+size 102023


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config-0.11.1


### Test plan

- [ ] Base branch is `release` (**DNM into main yet!**)
- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.11.1
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/2d39ab2
- [ ] CI is passing, the rpm is properly signed with the prod key
- [ ] Unsigned RPM after running `rpm --delsign` (in Debian Stable) on the signed RPM results in the checksum found in the build logs
