### PR TITLE
Add securedrop-workstation-dom0-config 1.0.0 RPM

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.0-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.0-1.fc37.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e723a6c2ebe28300fb77c10d954c8155bfa88efc59b9baf5e1fea557044f92a
+oid sha256:2390a426a385c7d8d778fbc92f4dbab805ab75caf83e257b3161cf4d2fb23cec
 size 92512

--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.0-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.0-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e723a6c2ebe28300fb77c10d954c8155bfa88efc59b9baf5e1fea557044f92a
+size 92512


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config

Refs https://github.com/freedomofpress/securedrop-workstation/issues/1103

### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.0.0
- [x] Can identically reproduce unsigned RPM
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/b47c0e9d60355f68e3f0b74fed963946a99a2454
- [x] CI is passing, the rpm is properly signed with the prod key
- [x] Unsigned RPM after running `rpm --delsign` (in Fedora 40) on the signed RPM results in the checksum found in the build logs
