### PR TITLE
SecureDrop Workstation 1.0.2

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.2-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.2-1.fc37.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c8e43c065b2c3c02a4a94927919549ebddf2959011ff1d016035819917e44230
+oid sha256:d38333b3fb8a0225edab7a31acde2cfd9a1dd2a524ff3ae69839374207341d8b
 size 92431

--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.2-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.2-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8e43c065b2c3c02a4a94927919549ebddf2959011ff1d016035819917e44230
+size 92431


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config


### Test plan

- [ ] Tag in securedrop-workstation repository is correct - see internal repo
- [ ] Build logs are included - see internal repo
- [ ] CI is passing, the rpm is properly signed with the prod key
- [ ] Unsigned RPM after running `rpm --delsign` (in Fedora 41) on the signed RPM results in the checksum found in the build logs
- [ ] Unsigned RPM was bit-for-bit reproduced
