### PR TITLE
SecureDrop Workstation 1.1.0

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.0-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.0-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8600ef8a01b5c332102eb835693a105df6ad591307ed659b8595b9ff561920c
+size 93430

--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.0-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.0-1.fc37.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d8600ef8a01b5c332102eb835693a105df6ad591307ed659b8595b9ff561920c
+oid sha256:425be02c75e894b1a6e7f063691ddfe6460a272dd1305bff07626b6a08fe4fd3
 size 93430


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config

Refs: https://github.com/freedomofpress/securedrop-workstation/issues/1209

### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.1.0
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/879e7ffa9f1c97d5310aab45c3dd61da8298378a
- [ ] CI is passing, the rpm is properly signed with the prod key
- [ ] Unsigned RPM after running `rpm --delsign` (in Debian Stable) on the signed RPM results in the checksum found in the build logs
- [ ] Unsigned RPM was bit-for-bit reproduced (step taken from https://github.com/freedomofpress/securedrop-yum-prod/pull/58)
