### PR TITLE
Release SecureDrop Workstation 1.1.1

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.1-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.1-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5f27a8295023495470499fb8c35dbbca3b8e6837a3aa2c1bfec929dc1861b24
+size 93496

--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.1-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.1-1.fc37.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5f27a8295023495470499fb8c35dbbca3b8e6837a3aa2c1bfec929dc1861b24
+oid sha256:108273fb4d1886a4c387f1b0c46096e92b605127cee40828a89ef43dbef51e2d
 size 93496


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config 1.1.1


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.1.1
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/bc253a2843b274a327151cf52af569e5ec9e35da
- [x] CI is passing, the rpm is properly signed with the prod key
- [x] Unsigned RPM after running `rpm --delsign` (with RPM >= 4.18.1) on the signed RPM results in the checksum found in the build logs
- [x] RPM was bit-for-bit independently reproduced