### PR TITLE
Update PR template instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,4 +7,5 @@ Name of package:
 - [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/x.y.z
 - [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/1234
 - [ ] CI is passing, the rpm is properly signed with the prod key
-- [ ] Unsigned RPM after running `rpm --delsign` (in Debian Stable) on the signed RPM results in the checksum found in the build logs
+- [ ] Unsigned RPM after running `rpm --delsign` (use same version of rpmsign from the build container) on the signed RPM results in the checksum found in the build logs
+- [ ] RPM independently bit-for-bit reproduced by another maintainer


### PR DESCRIPTION
Update PR instructions to clarify that rpmsign is what matters for rpm --delsign check. Add review checklist item to independently reproduce rpm build. 