### PR TITLE
ci: output the hashes of all RPM packages without their signatures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,19 @@ jobs:
       - name: Verify the signatures of all rpm artifacts
         run: |
           ./scripts/check.py --verify --all
+
+  tests-fedora:
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    steps:
+      - run: dnf install --assumeyes git git-lfs python3 rpm-sign
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      # This step must run on Fedora until Debian has RPM >= 4.18.1 (per
+      # securedrop-workstation#846), at which time it can be merged into the
+      # main "tests" job.
+      - name: Output the hashes of all rpm artifacts without their signatures
+        run: |
+          ./scripts/check.py --check-unsigned --all


### PR DESCRIPTION
#61 proposes to have reviewers check that:

https://github.com/freedomofpress/securedrop-yum-prod/blob/b5e9cae42fdb45c067f2a71ffe965f3bf2af6ec9/.github/pull_request_template.md?plain=1#L10

I think this is worth automating just one step further, indeed a step towards automating it entirely as anticipated by freedomofpress/securedrop-builder#418, as we already do for `.deb` packages from their `.buildinfo` files.